### PR TITLE
Add entity_label to alert and rework fallback

### DIFF
--- a/functions/slackRax/main.py
+++ b/functions/slackRax/main.py
@@ -25,18 +25,22 @@ def make_payload(rax_json):
     alarm_state = rax_json['details']['state']
     alarm_status = rax_json['details']['status']
     check_label = rax_json['check']['label']
+    entity_label = rax_json['entity']['label']
     dashboard_link = rax_json['dashboard_link']
 
     payload = {'attachments': [
         {
-            'fallback': 'ALERT WOW!',
-            'text': 'New Rackspace Monitoring Alert!',
+            'fallback': "Rackspace Monitoring Alert: %s - %s" % (check_label, entity_label),
+            'text': 'Rackspace Monitoring Alert!',
             'fields': [
                 {'title': 'Target',
                  'value': target,
                  'short': True},
                 {'title': 'Check',
                  'value': check_label,
+                 'short': True},
+                {'title': 'Entity Label',
+                 'value': entity_label,
                  'short': True},
                 {'title': 'Status',
                  'value': "%s - %s" % (alarm_state, alarm_status),


### PR DESCRIPTION
Though Slack does appear to do hostname lookups
on the items that appear in the popup
notifications in OS X, we cannot always rely
on the hostname being accurate.

To solve this, adding we will add entity_label
to the content of the alert as this will allow
users to see the friendly "label" of an entity.

Example:
```
...
    "entity": {
        "id": "enphGlgpQy",
        "label": "test",
...
```

This commit also reworks the "fallback" message
that we send to slack.

The fallback message is what Slack uses to
populate the contents of a popup message that
is not rendered directly in a Slack client.

Things like popup notifications on iOS, or
OSX, etc, use this "fallback" to generate
a preview of the alert message.

By adding better content to this message,
admins responding to alerts will be able to
determine if they need to respond to the alert
or not.


## Before:
<img width="433" alt="Screen Shot 2019-10-04 at 5 50 53 PM" src="https://user-images.githubusercontent.com/1891697/66244893-39463800-e6d0-11e9-899b-ad0830f86d55.png">

![Screen Shot 2019-10-04 at 5 50 26 PM](https://user-images.githubusercontent.com/1891697/66244946-76aac580-e6d0-11e9-81a8-ca8647033629.png)


## After:
![Screen Shot 2019-10-04 at 5 56 29 PM](https://user-images.githubusercontent.com/1891697/66244914-51b65280-e6d0-11e9-9d38-bdd0851eeca6.png)

<img width="460" alt="Screen Shot 2019-10-04 at 6 03 05 PM" src="https://user-images.githubusercontent.com/1891697/66245102-444d9800-e6d1-11e9-9d24-c6fb97b75880.png">


Signed-off-by: Evan Gray <evanscottgray@gmail.com>